### PR TITLE
Hotfix - Learning angles

### DIFF
--- a/states.py
+++ b/states.py
@@ -22,8 +22,8 @@ class PhysicalState:
         self.r = r
         self.dt = dt
     def get_learning_state(self):
-        angle = floor(self.theta/(pi/9))
-            #Assigns the angle to one of 9 sections
+        angle = min(9, floor(self.theta/(pi/10)))
+            #Assigns the angle to one of 10 sections
         if abs(self.v) >= 2*pi:
             velocity = 3
         elif abs(self.v) >= pi:


### PR DESCRIPTION
## Issue being fixed
- The specification for `LearningState` says that `angle` is an int in the range [0, 9] inclusive -- this means a total of 10 angles.  However, before this hotfix, there were functionally only 9 angles; a 10th angle was only available when theta was **exactly** pi.  With this arrangement, the zenith angle was 4, which made the reward function asymmetric, because the reward function rewards angles 4 and 5 equally.

## Solution
- In `get_learning_state()`...
    - ...divide by 10 rather than 9 to find `angle`, and...
    - take the `min` of that value and 9 to ensure an 11th angle doesn't exist when theta is exactly pi.